### PR TITLE
Disable automerging of experimental version

### DIFF
--- a/default.json
+++ b/default.json
@@ -24,5 +24,11 @@
       }
     }
   ],
-  "prHourlyLimit": 0
+  "prHourlyLimit": 0,
+  "packageRules": [
+    {
+      "matchCurrentVersion": "<1.0.0",
+      "automerge": false
+    }
+  ]
 }


### PR DESCRIPTION
## What?
Disable automerging of experimental version

## Why?
v1 未満のライブラリは、メジャーバージョン以外でも破壊的変更が入りがちだから